### PR TITLE
Make test for debug output more tolerant of white-space.

### DIFF
--- a/t/live-test.t
+++ b/t/live-test.t
@@ -29,8 +29,8 @@ like $log, qr{NotASecret}, 'other response headers left untouched is filtered';
 $logger->CLEAR;
 $mech->{catalyst_debug} = 1;
 my $error_screen = $mech->get('http://localhost/boom?foo_param=secret')->content;
-my $expected_debug = "parameters       =&gt; { foo_param =&gt; &quot;[FILTERED]&quot; }";
-like $error_screen, qr/\Q$expected_debug/, 'filtered on debug screen';
+my $expected_debug = qr/parameters\s+=&gt; { foo_param =&gt; &quot;\[FILTERED\]&quot; }/;
+like $error_screen, $expected_debug, 'filtered on debug screen';
 
 use HTTP::Request::Common;
 my $file_contents = "This is my file!";


### PR DESCRIPTION
The test was failing with Catalyst 5.90097.
