### PR TITLE
escape curly brace in regex because of test failures starting in 5.26.0

### DIFF
--- a/t/live-test.t
+++ b/t/live-test.t
@@ -29,7 +29,7 @@ like $log, qr{NotASecret}, 'other response headers left untouched is filtered';
 $logger->CLEAR;
 $mech->{catalyst_debug} = 1;
 my $error_screen = $mech->get('http://localhost/boom?foo_param=secret')->content;
-my $expected_debug = qr/parameters\s+=&gt; { foo_param =&gt; &quot;\[FILTERED\]&quot; }/;
+my $expected_debug = qr/parameters\s+=&gt; \{ foo_param =&gt; &quot;\[FILTERED\]&quot; \}/;
 like $error_screen, $expected_debug, 'filtered on debug screen';
 
 use HTTP::Request::Common;


### PR DESCRIPTION
Single `{` need to be escaped from Perl 5.26.0, see http://perldoc.perl.org/perl5260delta.html#Unescaped-literal-%22%7b%22-characters-in-regular-expression-patterns-are-no-longer-permissible. This fixes https://rt.cpan.org/Public/Bug/Display.html?id=115606.